### PR TITLE
Introduce Error Template for consistent formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,7 @@ let config = {
   status: 500,
   debug: false,
   logger: err => console.warn(err._name, err),
-  responseTemplate: {
-    error_code: "error_code",
-    error_type: "error_type",
-    error_message: "error_message",
-    error_context: "error_context",
-    error_fields: "error_fields",
-  }
+  responseTemplate: {},
 };
 
 /**
@@ -232,15 +226,27 @@ const getStatus = function(err) {
  * @return {object}                     Error Response Object
  */
 const getResponse = function(err) {
+  const responses = Object.keys(err._response)
+    .filter(function (response) {
+      if (err._template.includes(response)) {
+        return response;
+      }
+    })
+    .reduce(function (obj, key) {
+      obj[key] = err._response[key];
+      return obj;
+    }, {});
   return {
-    [err._template.error_code]: err._response[err._template.error_code],
-    [err._template.error_type]: err._response[err._template.error_type],
-    [err._template.error_message]: err._response[err._template.error_message],
-    [err._template.error_context]: err._response[err._template.error_context],
-    [err._template.error_field]: err._response[err._template.error_field],
+    responses,
   };
 }
 
 // exports
 
-module.exports = { setup, repeat, stop, getStatus };
+module.exports = {
+  setup,
+  repeat,
+  stop,
+  getStatus,
+  getResponse,
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@ let config = {
   status: 500,
   debug: false,
   logger: err => console.warn(err._name, err),
+  responseTemplate: {
+    error_code: "error_code",
+    error_type: "error_type",
+    error_message: "error_message",
+    error_context: "error_context",
+    error_fields: "error_fields",
+  }
 };
 
 /**
@@ -51,6 +58,8 @@ const report = function(err, opts) {
     status=config.status,
     context=null,
     req=null,
+    template=config.responseTemplate,
+    response=null
   } = opts;
 
   err._reported    = true;
@@ -58,6 +67,8 @@ const report = function(err, opts) {
   err._status     = status;
   err._context    = context;
   err._time       = Math.floor(Date.now());
+  err._template   = template;
+  err._response   = response;
 
   if (req) {
     err._ipAddr      = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
@@ -211,6 +222,23 @@ const stop = function(err, opts={}) {
  */
 const getStatus = function(err) {
   return err._status || config.status;
+}
+
+/**
+ * Generate an error response for the error.
+ *
+ * @param {object}      err             Main error object or custom.
+ *
+ * @return {object}                     Error Response Object
+ */
+const getResponse = function(err) {
+  return {
+    [err._template.error_code]: err._response[err._template.error_code],
+    [err._template.error_type]: err._response[err._template.error_type],
+    [err._template.error_message]: err._response[err._template.error_message],
+    [err._template.error_context]: err._response[err._template.error_context],
+    [err._template.error_field]: err._response[err._template.error_field],
+  };
 }
 
 // exports


### PR DESCRIPTION
I'm thinking we can use this `responseTemplate` option to define a format for the error response.

For example:
```
nodeErr.repeat(error, {
  status: 422,
  name: 'LUGGAGE COMBINATION ERROR,
  response: {
    code: '12345',
    message: "That's the same as my luggage!",
    thisWillBeIgnored: "Bleeps sweeps and creeps",
  },
});
```

This would allow a simple middleware to spit out a consistent error message upon hitting an error:

```
nodeErr.setup({
   responseTemplate: [
     'code',
     'message',
   ],
});

  app.use((err, req, res, next) => {
    res.status(nodeErr.getStatus(err))
      .send(nodeErr.getResponse(err));
  });
```

The result is now you an render something like this as an api response:
```
{
  "code": "12345",
  "message": "That's the same as my luggage!"
}
```